### PR TITLE
Add a line to WPXA.ahk to #include WinGetPosEx

### DIFF
--- a/WPXA.ahk
+++ b/WPXA.ahk
@@ -64,6 +64,9 @@ Author(s):
     20110713 - hoppfrosch - Original
 ===============================================================================
 */
+
+#include %A_ScriptDir%/WinGetPosEx.ahk
+
 WPXA_version()
 {
     Global Version


### PR DESCRIPTION
Trying to run WindowPadX was failing (at least in AHK v1.1) with the error
that it was trying to call the nonexistent function WinGetPosEx.

This was due to a missing #include line to the file WinGetPosEx.ahk. This
has now been added, and the script can run and compile again.