### PR TITLE
Fixes two issues for Windows 10:  monitors with different scaling, and taskbar getting moved 

### DIFF
--- a/WindowPadX.ahk
+++ b/WindowPadX.ahk
@@ -39,7 +39,7 @@ Version History:
 
 --------------------------------------------------------------------------------------
 Ideensammlung:
-* Transparenz für Fenster
+* Transparenz fï¿½r Fenster
 * Overlay-Icon in Taskbar, um anzuzeigen auf welchem Screen sich das Fenster befindet ... (Funktion aus ITaskBar von maul.esel). Dies sollte bei verlassen des Programmes auch wieder entfernt werden.
   Hinweise:
   * http://www.autohotkey.com/forum/viewtopic.php?t=74314
@@ -111,6 +111,13 @@ WindowPadX_Init(IniPath="")
     }
     WINDOWPADX_INI_PATH := IniPath
     WindowPadX_LoadSettings(IniPath)
+
+    ; Sets Windows Dpi Awareness context for thread so that it uses per-monitor DPI scaling.
+    ; Otherwise there will be issues if using monitors with different scaling for calculating window position, since it will use the scaling of main monitor.
+    ; SetThreadDpiAwarenessContext function description: https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setthreaddpiawarenesscontext
+    ; Argument '-3' sets context to 'DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE':  https://docs.microsoft.com/en-gb/windows/win32/hidpi/dpi-awareness-context
+    ; Without running the line below, it will use -2 DPI_AWARENESS_CONTEXT_SYSTEM_AWARE
+    DllCall("SetThreadDpiAwarenessContext", "ptr", -3, "ptr")
 }
 
 WindowPadX_LoadSettings(ininame)

--- a/WindowPadX.ini
+++ b/WindowPadX.ini
@@ -113,6 +113,11 @@ Window=ahk_class SideBar_AppBarWindow
 Window=ahk_class SideBar_HTMLHostWindow
 Window=ahk_class BasicWindow
 
+; To prevent Windows 10 taskbar from getting moved with gather all command (ahk_class found with WindowSpy)
+Window=ahk_class Shell_TrayWnd
+Window=ahk_class Shell_SecondaryTrayWnd
+Window=ahk_class Windows.UI.Core.CoreWindow
+
 ;
 ; [Gather: Exclude Processes]: WPXA_GatherWindowsOnMonitor ignores windows belonging to these processes.
 ;                              It is usually not necessary to use both this and the above.


### PR DESCRIPTION
Fixes issue #23 scaling of windows on monitors with different DPI than main monitor.
See added code on L120 of WindowPadX.ahk.

Fixes issue where windows 10 task bar on secondary monitor, and notification sidebar would also get moved when calling WPXA_GatherWindowsOnMonitor.
See added code on L116-L119.

PS:
Only 4 lines has been added to the ini file.
It seems that the online ini-file had CRLF endings, while my git setup only uses CRLF locally, and converts to LF when pushing (and then back to CRLF when pulling).