### PR TITLE
Fix detailed documentation github URL link

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,7 @@
 WindowPadX
 ==========
 
-Detailed Documentation can be found here: http://hoppfrosch.github.com/WindowPadX/files/WindowPadX-ahk.html
+Detailed Documentation can be found here: http://hoppfrosch.github.io/WindowPadX/files/WindowPadX-ahk.html
 
 Introduction
 ------------
@@ -33,4 +33,4 @@ Features
       - General
           - WPXA_MouseLocator: Easy find the mouse 
 
-For more details see http://hoppfrosch.github.com/WindowPadX/files/WindowPadX-ahk.html
+For more details see http://hoppfrosch.github.io/WindowPadX/files/WindowPadX-ahk.html


### PR DESCRIPTION
From hoppfrosch.github.com:

> If you're the owner of this site, please update your links to use hoppfrosch.github.io instead.
Subdomains of github.com are deprecated for GitHub Pages.
They will not redirect to github.io after April 15, 2021.